### PR TITLE
Update

### DIFF
--- a/check-pipelines.py
+++ b/check-pipelines.py
@@ -201,9 +201,7 @@ The types of changes are as follows:
         # Entries here are currently used in the ansible-core test matrix.
         expected = {
             'alpine3': 'alpine',
-            'centos6': 'centos',
             'centos7': 'centos',
-            'centos8': 'centos',
             'fedora33': 'fedora',
             'fedora34': 'fedora',
             'opensuse15': 'opensuse',
@@ -219,6 +217,8 @@ The types of changes are as follows:
     
         # Entries here are deprecated and will be removed from ansible-test in the future.
         deprecated = {
+            'centos6': 'centos',
+            'centos8': 'centos',
             'fedora30': 'fedora',
             'fedora31': 'fedora',
             'fedora32': 'fedora',


### PR DESCRIPTION
Update matrix checking:

- Deprecate centos6 container since since Python 2.6 support was dropped.
- Deprecate centos8 container since CentOS 8 will be EOL at the end of the year.
- Add support for ansible-core 2.12.
- Refactor code and add support for `--minimal` and `--action` arguments for matrix checking.