### PR TITLE
Overhaul matrix reporting

### DIFF
--- a/check-pipelines.py
+++ b/check-pipelines.py
@@ -27,21 +27,6 @@ def main() -> None:
     matrix_parser = subparsers.add_parser('matrix', help='check matrix configurations')
     matrix_parser.set_defaults(command=CheckMatrix)
 
-    matrix_parser.add_argument(
-        '--minimal',
-        action='store_true',
-        help='omit current and skipped projects',
-    )
-
-    actions = ['add', 'remove', 'consider']
-    matrix_parser.add_argument(
-        '--action',
-        dest='actions',
-        action='append',
-        choices=actions,
-        help=f'action(s) to show: {", ".join(actions)}',
-    )
-
     container_parser = subparsers.add_parser('container', help='check default containers')
     container_parser.set_defaults(command=CheckContainer)
 
@@ -138,144 +123,76 @@ A report on each project's status can be found below.
 
 class CheckMatrix:
     def __init__(self, args: argparse.Namespace, settings: Settings) -> None:
-        self.actions: t.List[str] = args.actions or ['add', 'remove', 'consider']
-        self.minimal: bool = args.minimal
         self.settings = settings
 
     def run(self) -> None:
-        self.matrix_boilerplate()
+        checklist = ''
 
         for config in self.settings.configs:
             if config.namespace == 'ansible' and config.name == 'ansible' and config.branch != 'devel':
                 continue
 
-            self.process_matrix(config)
+            checklist += self.process_matrix(config)
 
-    def matrix_boilerplate(self) -> None:
-        actions = dict(
-            add='The platform is already tested by the project, but the version is not. Add the version to the matrix.',
-            remove='The platform and version are deprecated and will be removed from `ansible-test` in the future. Remove the version from the matrix.',
-            consider='The platform is not yet tested by the project. Consider adding the version to the matrix.',
-        )
-
-        action_text = '\n'.join(f'- {action.title()} - {description}' for action, description in actions.items() if action in self.actions)
-
-        statuses = dict(
-            skipped='The project was skipped because it does not use platforms that were evaluated. No action is necessary.',
-            current='The project uses platforms that were evaluated, and all are current. No action is necessary.',
-            update='The project uses platforms that were evaluated, and one or more changes are indicated.',
-        )
-
-        status_text = '\n'.join(f'- {status.title()} - {description}' for status, description in statuses.items() if status == 'update' or not self.minimal)
+        if not checklist:
+            return
 
         print(f'''
 ### Azure Pipelines Test Matrix Updates
 
-Projects using Azure Pipelines to test against the `ansible-core` `devel` branch have been checked to verify their test matrix is up-to-date.
+The following collections tested with the `devel` branch of `ansible-core` should be updated:
 
-A report on each project's status, as well as the required and recommended actions are explained below.
+{checklist.strip()}
+'''.strip())
 
-#### Using the Checklist  
-
-Each project is given a status as follows:
-
-{status_text}
-
-The types of changes are as follows:
-
-{action_text}
-
-> IMPORTANT: These changes should **only** be made for the portion of the test matrix tested against the `devel` branch of `ansible-core`.
-
-#### Checklist
-''')
-
-    def process_matrix(self, config: Config) -> None:
+    def process_matrix(self, config: Config) -> str:
         namespace, name, branch, path = config
     
         stages = config.yaml['stages']
 
-        # Every platform/version combination known to ansible-test in the devel branch should be listed in one of the two lists below.
+        # Every platform/version combination known to ansible-test in the devel branch should be listed below.
         # The key is the value used for --remote or --docker.
-        # The value is the platform group the target is part of.
-        # The platform groups are used to distinguish between "Add" and "Consider" when generating the checklist.
-    
-        # Entries here are currently used in the ansible-core test matrix.
-        expected = {
-            'alpine3': 'alpine',
-            'centos7': 'centos',
-            'fedora37': 'fedora',
-            'opensuse15': 'opensuse',
-            'ubuntu2004': 'ubuntu',
-            'ubuntu2204': 'ubuntu',
-            'alpine/3.17': 'alpine',
-            'fedora/37': 'fedora',
-            'freebsd/12.4': 'freebsd',
-            'freebsd/13.1': 'freebsd',
-            'macos/13.2': 'macos',
-            'rhel/7.9': 'rhel',
-            'rhel/8.7': 'rhel',
-            'rhel/9.1': 'rhel',
-            'ubuntu/20.04': 'ubuntu',
-            'ubuntu/22.04': 'ubuntu',
+        # The value is a list of the entries which it replaces (if any). The values can be removed once they're no longer in any matrix.
+        # This is the only place updates should be required when adding/removing platforms.
+        # Be sure to add a new platform *and* define what it replaces at the same time.
+        platforms = {
+            'alpine3': [],
+            'centos7': [],
+            'fedora37': [],
+            'opensuse15': [],
+            'ubuntu2004': [],
+            'ubuntu2204': [],
+            'alpine/3.17': [],
+            'fedora/37': [],
+            'freebsd/12.4': [],
+            'freebsd/13.2': ['freebsd/13.1'],
+            'macos/13.2': [],
+            'rhel/7.9': [],
+            'rhel/8.7': [],
+            'rhel/9.1': [],
+            'ubuntu/20.04': [],
+            'ubuntu/22.04': [],
+            '': [],  # obsolete entries with no replacement go here
         }
-    
-        # Entries here are deprecated and will be removed from ansible-test in the future.
-        deprecated = {
-            'centos6': 'centos',
-            'centos8': 'centos',
-            'fedora30': 'fedora',
-            'fedora31': 'fedora',
-            'fedora32': 'fedora',
-            'fedora33': 'fedora',
-            'fedora34': 'fedora',
-            'fedora35': 'fedora',
-            'fedora36': 'fedora',
-            'opensuse15py2': 'opensuse',
-            'ubuntu1604': 'ubuntu',
-            'ubuntu1804': 'ubuntu',
-            'alpine/3.16': 'alpine',
-            'fedora/36': 'fedora',
-            'freebsd/11.1': 'freebsd',
-            'freebsd/11.4': 'freebsd',
-            'freebsd/12.1': 'freebsd',
-            'freebsd/12.2': 'freebsd',
-            'freebsd/12.3': 'freebsd',
-            'freebsd/13.0': 'freebsd',
-            'osx/10.11': 'macos',
-            'macos/10.15': 'macos',
-            'macos/11.1': 'macos',
-            'macos/12.0': 'macos',
-            'rhel/7.6': 'rhel',
-            'rhel/7.8': 'rhel',
-            'rhel/8.1': 'rhel',
-            'rhel/8.2': 'rhel',
-            'rhel/8.3': 'rhel',
-            'rhel/8.4': 'rhel',
-            'rhel/8.5': 'rhel',
-            'rhel/8.6': 'rhel',
-            'rhel/9.0': 'rhel',
-        }
-    
+
+        expected = set(platforms)
+        deprecated: dict[str, str] = {}
+
+        for platform, deprecated_platforms in platforms.items():
+            for deprecated_platform in deprecated_platforms:
+                if replacement := deprecated.get(deprecated_platform):
+                    raise RuntimeError(f'"{deprecated_platform}" is listed as replaced by both "{replacement}" and "{platform}"')
+
+                if deprecated_platform in platforms:
+                    raise RuntimeError(f'"{platform}" is listed as both a current and deprecated platform')
+
+                deprecated[deprecated_platform] = platform
+
         # Entries here are currently used in the ansible-core matrix, but are not recommended for collections.
         special = {
-            'ios/csr1000v': 'ios',
-            'vyos/1.1.8': 'vyos',
+            'ios/csr1000v',
+            'vyos/1.1.8',
         }
-
-        # Differentiate between containers and VMs when matching platforms for add/consider reporting.
-
-        for key, value in expected.items():
-            if '/' in key:
-                expected[key] += '-vm'
-            else:
-                expected[key] += '-container'
-
-        for key, value in deprecated.items():
-            if '/' in key:
-                deprecated[key] += '-vm'
-            else:
-                deprecated[key] += '-container'
 
         tests: list[tuple[str, str | None]] = []
 
@@ -366,49 +283,28 @@ The types of changes are as follows:
 
             tests_found.add(test_name)
     
-        unknown = tests_found - set(expected.keys()) - set(deprecated.keys()) - set(special.keys())
+        unknown = tests_found - expected - set(deprecated) - special
     
         if unknown:
             raise Exception(f'[{config.path}] Unknown test name: {unknown}')
-    
-        platforms = {test_name: expected.get(test_name) or deprecated.get(test_name) or special.get(test_name) for test_name in tests_found}
-    
-        if None in platforms.values():
-            raise Exception(f'Missing platform information: {platforms}')
-    
-        platforms_used = sorted(platforms.values())
-    
-        if not platforms_used:
-            if not self.minimal:
-                print(f'- [X] {namespace}.{name}:{branch} - Skipped')
 
-            return
+        result = ''
 
-        to_remove = (set(deprecated.keys()) & tests_found
-                     if 'remove' in self.actions else set())
+        for test_found in tests_found:
+            replacement = deprecated.get(test_found)
 
-        to_add = (set([name for name, platform in expected.items() if platform in platforms_used]) - tests_found
-                  if 'add' in self.actions else set())
+            if replacement is None:
+                continue
 
-        to_consider = (set([name for name, platform in expected.items() if platform not in platforms_used]) - tests_found
-                       if 'consider' in self.actions else set())
-    
-        if not to_add and not to_consider and not to_remove:
-            if not self.minimal:
-                print(f'- [X] {namespace}.{name}:{branch} - Current')
+            if replacement and replacement not in tests_found:
+                result += f'  - [ ] Replace `{test_found}` with `{replacement}`\n'
+            else:
+                result += f'  - [ ] Remove `{test_found}`\n'
 
-            return
-    
-        print(f'- [ ] {namespace}.{name}:{branch} - Update')
+        if result:
+            result = f'- [ ] {namespace}.{name}:{branch}\n{result}'
 
-        for item in sorted(to_remove):
-            print(f'  - [ ] Remove: {item}')
-
-        for item in sorted(to_add):
-            print(f'  - [ ] Add: {item}')
-
-        for item in sorted(to_consider):
-            print(f'  - [ ] Consider: {item}')
+        return result
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The reporting process is much simpler, and now supports only two use cases:

* Reporting entries which should be removed.
* Reporting entries which should be replaced.

Suggestions for adding new entries (except replacements) are no longer given.

To verify this works as expected I've added FreeBSD 13.2 as a replacement for FreeBSD 13.1 for https://github.com/ansible/ansible/pull/80698

The results from the report are:

```
### Azure Pipelines Test Matrix Updates

The following collections tested with the `devel` branch of `ansible-core` should be updated:

- [ ] community.crypto:main
  - [ ] Replace `freebsd/13.1` with `freebsd/13.2`
- [ ] community.general:stable-6
  - [ ] Replace `freebsd/13.1` with `freebsd/13.2`
- [ ] community.general:stable-5
  - [ ] Replace `freebsd/13.1` with `freebsd/13.2`
- [ ] community.general:main
  - [ ] Replace `freebsd/13.1` with `freebsd/13.2`
- [ ] ansible.posix:main
  - [ ] Replace `freebsd/13.1` with `freebsd/13.2`
- [ ] community.libvirt:main
  - [ ] Replace `freebsd/13.1` with `freebsd/13.2`
- [ ] ansible.ansible:devel
  - [ ] Replace `freebsd/13.1` with `freebsd/13.2`
```

Here's the same output, allowing the markdown to render:

### Azure Pipelines Test Matrix Updates

The following collections tested with the `devel` branch of `ansible-core` should be updated:

- [ ] community.crypto:main
  - [ ] Replace `freebsd/13.1` with `freebsd/13.2`
- [ ] community.general:stable-6
  - [ ] Replace `freebsd/13.1` with `freebsd/13.2`
- [ ] community.general:stable-5
  - [ ] Replace `freebsd/13.1` with `freebsd/13.2`
- [ ] community.general:main
  - [ ] Replace `freebsd/13.1` with `freebsd/13.2`
- [ ] ansible.posix:main
  - [ ] Replace `freebsd/13.1` with `freebsd/13.2`
- [ ] community.libvirt:main
  - [ ] Replace `freebsd/13.1` with `freebsd/13.2`
- [ ] ansible.ansible:devel
  - [ ] Replace `freebsd/13.1` with `freebsd/13.2`
